### PR TITLE
The last link of the manipulator should be updated as well

### DIFF
--- a/src/sclerp_interface.cpp
+++ b/src/sclerp_interface.cpp
@@ -152,7 +152,7 @@ ScLERPInterface::ScLERPInterface( const std::string base_link,
     }
     else
     {
-      if(itr < (manip_chain.getNrOfSegments()-1))
+      if(itr < (manip_chain.getNrOfSegments()))
       {
         manip.modifyEndJointTipPose(t_ref);
       }


### PR DESCRIPTION
I'm not sure if the "-1" is intended here because of the urdf of Baxter robot. But for general cases, "-1" should be removed.